### PR TITLE
DO NOT MERGE: See if labeler works

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,7 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- New shiny thing!
 
 API Changes
 -----------

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -15,6 +15,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
     """
 
     @property
+    def spooky(self):
+        return 'oooOOOooOOOooo'
+
+    @property
     @abc.abstractmethod
     def pixel_n_dim(self):
         """

--- a/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
@@ -67,6 +67,8 @@ def test_wrapper():
     assert wrapper.pixel_bounds is None
     assert np.all(wrapper.axis_correlation_matrix)
 
+    assert 'ooo' in wcs.spooky
+
 
 def test_wrapper_invalid():
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Should have 3 labels:

* Docs
* wcs.wcsapi
* testing

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

xref astropy/astropy#10974