### PR TITLE
EXP: see if milestone check works

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -8,8 +8,7 @@ jobs:
     name: Check if milestone is set
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2  
     - name: Check milestone
       uses: pllim/action-check_milestone_exists@main
-      id: custom_action_milestone
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_pr_milestone.yml
+++ b/.github/workflows/check_pr_milestone.yml
@@ -1,7 +1,8 @@
-name: Check PR
+name: Check PR milestone
 
 on:
   pull_request:
+    types: [opened, milestoned,  demilestoned]
 
 jobs:
   milestone:

--- a/.github/workflows/check_pr_milestone.yml
+++ b/.github/workflows/check_pr_milestone.yml
@@ -1,8 +1,10 @@
 name: Check PR milestone
 
 on:
-  pull_request:
-    types: [opened, milestoned,  demilestoned]
+  pull_request_target:
+    types: [opened]
+  issue:
+    types: [milestoned, demilestoned]
 
 jobs:
   milestone:

--- a/.github/workflows/check_pr_milestone.yml
+++ b/.github/workflows/check_pr_milestone.yml
@@ -3,7 +3,7 @@ name: Check PR milestone
 on:
   pull_request_target:
     types: [opened]
-  issue:
+  issues:
     types: [milestoned, demilestoned]
 
 jobs:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - master
     tags:
-  pull_request:
+#  pull_request:
 
 jobs:
   tests:

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Astropy
 =======
 
+Just a test
+
 |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status|
 
 The Astropy Project (http://astropy.org/) is a community effort to develop a


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

If this works correctly, the will be a milestone check where CI status shows up...

**Thoughts**

* Maybe having a job to post another check is overkill. Alternative: Do a brute force `sys.exit(1)` if no milestone to kill it to get the ❌ 
* Do we really need `baldrick` for this one? If `milestone` not in `github.event` context (I don't think it is), maybe PyGithub alone is enough.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
